### PR TITLE
README: Add note about Node v4+

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 ## Install
 
-Ensure you have [Node.js](https://nodejs.org) installed. Then run the following:
+Ensure you have [Node.js](https://nodejs.org) version 4+ installed. Then run the following:
 
 ```
 $ npm install --global fast-cli


### PR DESCRIPTION
Since `const` and other ES6 keywords do not work on earlier versions.