### PR TITLE
Adds an argument for logging speed to log.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+log.txt

--- a/cli.js
+++ b/cli.js
@@ -7,10 +7,14 @@ const chalk = require('chalk');
 const logUpdate = require('log-update');
 const ora = require('ora');
 const api = require('./api');
+const log = require('./log');
 
-meow(`
+const cli = meow(`
 	Usage
 	  $ fast
+
+	Options
+	  --log	Writes each speed measurement to log.txt
 `);
 
 // check connection
@@ -52,12 +56,16 @@ api((err, result) => {
 	data = result;
 
 	// exit after the speed has been the same for 3 sec
-	// needed as sometimes `isDone` doens't work for some reason
+	// needed as sometimes `isDone` doesn't work for some reason
 	clearTimeout(timeout);
 	timeout = setTimeout(() => {
 		data.isDone = true;
 		exit();
 	}, 5000);
+
+	if (cli.flags.log) {
+		log(data.speed);
+	}
 
 	if (data.isDone) {
 		exit();

--- a/log.js
+++ b/log.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const fs = require('fs')
+
+module.exports = data => {
+  fs.appendFile('log.txt', data + '\n', err => {
+    if (err) throw err;
+  });
+};


### PR DESCRIPTION
This adds the `--log` argument, which is parsed with meow and logs each speed result to a hardcoded file, `log.txt`.

I'm planning to use this in a project where I measure my home bandwidth speed, so I want the raw data to generate charts and stuff.

I'll probably be riffing on this for a little bit, so let me know if you think it's useful and if have any feedback.