### PR TITLE
non-tty friendly output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -27,20 +27,23 @@ const spinner = ora();
 const speed = () => chalk[data.isDone ? 'green' : 'cyan'](data.speed + ' ' + chalk.dim(data.unit)) + '\n\n';
 
 function exit() {
-	logUpdate('\n\n    ' + speed());
+	const output = process.stdout.isTTY ? `\n\n    ${speed()}` : `${data.speed} ${data.unit}`;
+	logUpdate(output);
 	process.exit();
 }
 
-setInterval(() => {
-	const pre = '\n\n  ' + chalk.gray.dim(spinner.frame());
+if (process.stdout.isTTY) {
+	setInterval(() => {
+		const pre = '\n\n  ' + chalk.gray.dim(spinner.frame());
 
-	if (!data.speed) {
-		logUpdate(pre + '\n');
-		return;
-	}
+		if (!data.speed) {
+			logUpdate(pre + '\n');
+			return;
+		}
 
-	logUpdate(pre + speed());
-}, 50);
+		logUpdate(pre + speed());
+	}, 50);
+}
 
 let timeout;
 


### PR DESCRIPTION
If stdout is not a tty device, omit spinner and simply print the final speed when done

```
fast-cli (master) $ node cli.js | cat
16 Mbps
```

I use this feature for running fast-cli on a schedule and saving its output to a file