### PR TITLE
Do not print ANSI escapes if stdout is not a TTY

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -28,8 +28,12 @@ const spinner = ora();
 const speed = () => chalk[data.isDone ? 'green' : 'cyan'](data.speed + ' ' + chalk.dim(data.unit)) + '\n\n';
 
 function exit() {
-	const output = process.stdout.isTTY ? `\n\n    ${speed()}` : `${data.speed} ${data.unit}`;
-	logUpdate(output);
+    if (process.stdout.isTTY) {
+        logUpdate(`\n\n    ${speed()}`);
+    } else {
+        console.log(`${data.speed} ${data.unit}`);
+    }
+
 	process.exit();
 }
 

--- a/test.js
+++ b/test.js
@@ -15,5 +15,5 @@ test.cb('default', t => {
 });
 
 test('non-tty', async t => {
-	t.regex(await execa.stdout('./cli.js'), /\d+ \w/i);
+	t.regex(await execa.stdout('./cli.js'), /^\d+(?:\.\d+)? \w+$/i);
 });


### PR DESCRIPTION
`logUpdate` surrounds the output text with ANSI escape codes (`CSI ?25l` and `CSI ?25h`, [which hide and show the cursor](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_codes)), even when stdout is not a TTY:
```
> ./cli.js | xxd
00000000: 1b5b 3f32 356c 3233 3020 4b62 7073 0a1b  .[?25l230 Kbps..
00000010: 5b3f 3235 68                             [?25h
```
This is problematic if trying to process the output, for example, tabulating.

Before this PR:
```
> for i in $(seq 1 3); do; ./cli.js; done | column -t
column: line too long
6.4       Mbps
6.7  Mbps
5.9  Mbps
```
With this PR's changes:
```
> for i in $(seq 1 3); do; ./cli.js; done | column -t
8.9  Mbps
6.3  Mbps
5    Mbps
```
As you can see, the escapes have been removed:
```
> ./cli.js | xxd
00000000: 312e 3220 4d62 7073 0a                   1.2 Mbps.
```