### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+
+COPY . /src
+WORKDIR /src
+
+RUN npm install
+
+CMD ["node", "cli.js"]
+
+


### PR DESCRIPTION
This is a simple Dockerfile which allows the fast-cli to run in a container (I prefer this especially in projects with lots of dependencies).

It can be run with `docker run jasongwartz/fast-cli`, in which case it triggers the no-TTY codepath, or with `docker run -it jasongwartz/fast-cli` for the with-TTY codepath (and the nice animations 🙂).