### PR TITLE
Replace PhantomJS with Headless Chrome via puppeteer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
+  - '8'
   - '6'
-  - '4'

--- a/cli.js
+++ b/cli.js
@@ -49,22 +49,9 @@ if (process.stdout.isTTY) {
 	}, 50);
 }
 
-let timeout;
-
 api()
 	.forEach(result => {
 		data = result;
-		// Exit after the speed has been the same for 3 sec
-		// needed as sometimes `isDone` doesn't work for some reason
-		clearTimeout(timeout);
-		timeout = setTimeout(() => {
-			data.isDone = true;
-			exit();
-		}, 5000);
-
-		if (data.isDone) {
-			exit();
-		}
 	})
 	.then(() => exit())
 	.catch(err => {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fast": "cli.js"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6.4.0"
   },
   "scripts": {
     "test": "xo && ava"
@@ -45,8 +45,7 @@
     "log-update": "^1.0.0",
     "meow": "^3.3.0",
     "ora": "^1.2.0",
-    "phantomjs-prebuilt": "^2.1.7",
-    "promise-phantom": "^3.1.1",
+    "puppeteer": "^0.11.0",
     "zen-observable": "^0.5.1"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 ## Install
 
-Ensure you have [Node.js](https://nodejs.org) version 4+ installed. Then run the following:
+Ensure you have [Node.js](https://nodejs.org) version 6.4+ installed. Then run the following:
 
 ```
 $ npm install --global fast-cli


### PR DESCRIPTION
Updated to use [puppeteer](https://github.com/GoogleChrome/puppeteer) over now [un-maintained](https://groups.google.com/forum/#!topic/phantomjs/9aI5d-LDuNE) PhantomJS. Puppeteer is created and maintained by the official Google Chrome team which should ensure the longevity and stability of the project. fast-cli was currently leveraging promise-phantom which offers a very similar API to puppeteer, making this update fairly straightforward. 

This PR may resolve #2

**Pros:**
- Uses headless Chrome
- Better performance 
- Addresses several "hacks" / "fixes" in place to account for PhantomJS
- Library maintained by Google Chrome team
- Downloads chromium internally, removing need for a "prebuild" dependency

**Cons:**
- Have to bump minimum engine to 6.4.0 (LTS, still)
- The binary for headless Chrome is approximately 10x larger than that of PhantomJs