### PR TITLE
Fix Puppeteer launch bug Linux

### DIFF
--- a/api.js
+++ b/api.js
@@ -29,7 +29,7 @@ async function init(browser, page, observer, prevSpeed) {
 module.exports = () => new Observable(observer => {
 	// Wrapped in async IIFE as `new Observable` can't handle async function
 	(async () => {
-		const browser = await puppeteer.launch();
+		const browser = await puppeteer.launch({args: ['--no-sandbox']});
 		const page = await browser.newPage();
 
 		await page.goto('https://fast.com');


### PR DESCRIPTION
Hello,

This PR fix this bug : 
More details on this issue : https://github.com/Googlechrome/puppeteer/issues/290#issuecomment-322851507

```
Failed to launch chrome!                           
[0331/110132.054423:FATAL:zygote_host_impl_linux.cc(123)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
#0 0x5627b8b36857 base::debug::StackTrace::StackTrace()
#1 0x5627b8b4d041 logging::LogMessage::~LogMessage()      
#2 0x5627b7cfa711 content::ZygoteHostImpl::Init()  
#3 0x5627b798eda0 content::BrowserMainLoop::EarlyInitialization()
#4 0x5627b79952de content::BrowserMainRunnerImpl::Initialize()
#5 0x5627bc77cdd6 headless::HeadlessContentMainDelegate::RunProcess()         
#6 0x5627b88829e7 content::RunNamedProcessTypeMain()
#7 0x5627b8883421 content::ContentMainRunnerImpl::Run()
#8 0x5627b888c19d service_manager::Main()                              
#9 0x5627b8881f52 content::ContentMain()                                                               
#10 0x5627bc77c075 headless::(anonymous namespace)::RunContentMain()                   
#11 0x5627bc77c0ea headless::HeadlessBrowserMain()                                                                                                               
#12 0x5627b88891b1 headless::HeadlessShellMain()
#13 0x5627b72eb1bd ChromeMain                       
#14 0x7fe9eaae3f4a __libc_start_main                          
#15 0x5627b72eb029 <unknown>                    
          
Received signal 6                                   
#0 0x5627b8b36857 base::debug::StackTrace::StackTrace()
#1 0x5627b8b363bf base::debug::(anonymous namespace)::StackDumpSignalHandler()
#2 0x7fe9f0ed5dd0 <unknown>                                
#3 0x7fe9eaaf7860 __GI_raise                              
#4 0x7fe9eaaf8ec9 __GI_abort                           
#5 0x5627b8b35402 base::debug::BreakDebugger()              
#6 0x5627b8b4d42a logging::LogMessage::~LogMessage() 
#7 0x5627b7cfa711 content::ZygoteHostImpl::Init()             
#8 0x5627b798eda0 content::BrowserMainLoop::EarlyInitialization()
#9 0x5627b79952de content::BrowserMainRunnerImpl::Initialize()
#10 0x5627bc77cdd6 headless::HeadlessContentMainDelegate::RunProcess()
#11 0x5627b88829e7 content::RunNamedProcessTypeMain()
#12 0x5627b8883421 content::ContentMainRunnerImpl::Run()
#13 0x5627b888c19d service_manager::Main()                 
#14 0x5627b8881f52 content::ContentMain()                 
#15 0x5627bc77c075 headless::(anonymous namespace)::RunContentMain()
#16 0x5627bc77c0ea headless::HeadlessBrowserMain()          
#17 0x5627b88891b1 headless::HeadlessShellMain()     
#18 0x5627b72eb1bd ChromeMain                            
#19 0x7fe9eaae3f4a __libc_start_main
#20 0x5627b72eb029 <unknown>
  r8: 0000000000000000  r9: 00007fffcf627070 r10: 0000000000000008 r11: 0000000000000246
 r12: 00007fffcf627790 r13: 0000000000000161 r14: 00007fffcf627788 r15: 00007fffcf627780
  di: 0000000000000002  si: 00007fffcf627070  bp: 00007fffcf627330  bx: 0000000000000006
  dx: 0000000000000000  ax: 0000000000000000  cx: 00007fe9eaaf7860  sp: 00007fffcf627070               
  ip: 00007fe9eaaf7860 efl: 0000000000000246 cgf: 002b000000000033 erf: 0000000000000000          
 trp: 0000000000000000 msk: 0000000000000000 cr2: 0000000000000000                                                        
[end of stack trace]                                                                                                
Calling _exit(1). Core file will not be generated.                                                    
                                                                                             
                                                                              
TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
```