### PR TITLE
Add `--single-line` flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,7 @@ const cli = meow(`
 
 	Options
 	  --upload, -u  Measure upload speed in addition to download speed
-	  --oneline, -l  Reduce spacing and output on a single line
+	  --single-line  Reduce spacing and output on a single line
 
 	Examples
 	  $ fast --upload > file && cat file
@@ -26,9 +26,8 @@ const cli = meow(`
 			type: 'boolean',
 			alias: 'u'
 		},
-		oneline: {
-			type: 'boolean',
-			alias: 'l'
+		'single-line': {
+			type: 'boolean'
 		}
 	}
 });
@@ -48,8 +47,8 @@ dns.lookup('fast.com', error => {
 let data = {};
 const spinner = ora();
 
-const lineBreak = amount => (cli.flags.oneline ? '' : '\n'.repeat(amount));
-const spacing = amount => (cli.flags.oneline ? '' : ' '.repeat(amount));
+const lineBreak = amount => (cli.flags.singleLine ? '' : '\n'.repeat(amount));
+const spacing = amount => (cli.flags.singleLine ? '' : ' '.repeat(amount));
 
 const downloadSpeed = () =>
 	`${data.downloadSpeed} ${chalk.dim(data.downloadUnit)} ↓`;

--- a/cli.js
+++ b/cli.js
@@ -14,6 +14,7 @@ const cli = meow(`
 
 	Options
 	  --upload, -u  Measure upload speed in addition to download speed
+	  --oneline, -l  Reduce spacing and output on a single line
 
 	Examples
 	  $ fast --upload > file && cat file
@@ -24,6 +25,10 @@ const cli = meow(`
 		upload: {
 			type: 'boolean',
 			alias: 'u'
+		},
+		oneline: {
+			type: 'boolean',
+			alias: 'l'
 		}
 	}
 });
@@ -31,13 +36,20 @@ const cli = meow(`
 // Check connections
 dns.lookup('fast.com', error => {
 	if (error && error.code === 'ENOTFOUND') {
-		console.error(chalk.red('\n Please check your internet connection.\n'));
+		console.error(
+			chalk.red(
+				`${lineBreak(1)}${spacing(1)}Please check your internet connection.${lineBreak(1)}`
+			)
+		);
 		process.exit(1);
 	}
 });
 
 let data = {};
 const spinner = ora();
+
+const lineBreak = amount => (cli.flags.oneline ? '' : '\n'.repeat(amount));
+const spacing = amount => (cli.flags.oneline ? '' : ' '.repeat(amount));
 
 const downloadSpeed = () =>
 	`${data.downloadSpeed} ${chalk.dim(data.downloadUnit)} ↓`;
@@ -56,11 +68,11 @@ const speedText = () =>
 		`${downloadColor(downloadSpeed())} ${chalk.dim('/')} ${uploadColor(uploadSpeed())}` :
 		downloadColor(downloadSpeed());
 
-const speed = () => speedText() + '\n\n';
+const speed = () => speedText() + lineBreak(2);
 
 function exit() {
 	if (process.stdout.isTTY) {
-		logUpdate(`\n\n    ${speed()}`);
+		logUpdate(`${lineBreak(2)}${spacing(4)}${speed()}`);
 	} else {
 		let output = `${data.downloadSpeed} ${data.downloadUnit}`;
 
@@ -76,10 +88,10 @@ function exit() {
 
 if (process.stdout.isTTY) {
 	setInterval(() => {
-		const pre = '\n\n  ' + chalk.gray.dim(spinner.frame());
+		const pre = lineBreak(2) + spacing(2) + chalk.gray.dim(spinner.frame());
 
 		if (!data.downloadSpeed) {
-			logUpdate(pre + '\n\n');
+			logUpdate(pre + lineBreak(2));
 			return;
 		}
 

--- a/cli.js
+++ b/cli.js
@@ -13,7 +13,7 @@ const cli = meow(`
 	  $ fast > file
 
 	Options
-	  --upload, -u  Measure upload speed in addition to download speed
+	  --upload, -u   Measure upload speed in addition to download speed
 	  --single-line  Reduce spacing and output on a single line
 
 	Examples

--- a/cli.js
+++ b/cli.js
@@ -26,7 +26,7 @@ const cli = meow(`
 			type: 'boolean',
 			alias: 'u'
 		},
-		'single-line': {
+		singleLine: {
 			type: 'boolean'
 		}
 	}

--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,7 @@ const cli = meow(`
 
 	Options
 	  --upload, -u   Measure upload speed in addition to download speed
-	  --single-line  Reduce spacing and output on a single line
+	  --single-line  Reduce spacing and output to a single line
 
 	Examples
 	  $ fast --upload > file && cat file

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ $ fast --help
 
   Options
     --upload, -u   Measure upload speed in addition to download speed
-    --single-line  Reduce spacing and output on a single line
+    --single-line  Reduce spacing and output to a single line
 
   Examples
     $ fast --upload > file && cat file

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ $ fast --help
     $ fast > file
 
   Options
-    --upload, -u  Measure upload speed in addition to download speed
+    --upload, -u   Measure upload speed in addition to download speed
     --single-line  Reduce spacing and output on a single line
 
   Examples

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ $ fast --help
 
   Options
     --upload, -u  Measure upload speed in addition to download speed
+    --single-line  Reduce spacing and output on a single line
 
   Examples
     $ fast --upload > file && cat file


### PR DESCRIPTION
Alias set to `l` as an `o` seemed synonymous with output. Another option would be `--minimal`; however, this word felt like it should remove colors and spinner.