### PR TITLE
Add `--json` flag

### DIFF
--- a/api.js
+++ b/api.js
@@ -15,9 +15,15 @@ async function init(browser, page, observer, options) {
 
 			return {
 				downloadSpeed: Number($('#speed-value').textContent),
-				uploadSpeed: Number($('#upload-value').textContent),
 				downloadUnit: $('#speed-units').textContent.trim(),
+				downloadedMb: Number($('#down-mb-value').textContent.trim()),
+				uploadSpeed: Number($('#upload-value').textContent),
 				uploadUnit: $('#upload-units').textContent.trim(),
+				uploadedMb: Number($('#up-mb-value').textContent.trim()),
+				latency: Number($('#latency-value').textContent.trim()),
+				bufferBloat: Number($('#bufferbloat-value').textContent.trim()),
+				userLocation: $('#user-location').textContent.trim(),
+				userIp: $('#user-ip').textContent.trim(),
 				isDone: Boolean(
 					$('#speed-value.succeeded') && $('#upload-value.succeeded')
 				)

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,7 @@ const chalk = require('chalk');
 const logUpdate = require('log-update');
 const ora = require('ora');
 const api = require('./api');
-const { clearCustomQueryHandlers } = require('puppeteer');
+//tllakfdja
 
 const cli = meow(`
 	Usage
@@ -59,8 +59,8 @@ dns.lookup('fast.com', error => {
 let data = {};
 const spinner = ora();
 
-const lineBreak = amount => (cli.flags.singleLine||cli.flags.json||cli.flags.jsonPretty ? '' : '\n'.repeat(amount));
-const spacing = amount => (cli.flags.singleLine||cli.flags.json||cli.flags.jsonPretty ? '' : ' '.repeat(amount));
+const lineBreak = amount => (cli.flags.singleLine || cli.flags.json || cli.flags.jsonPretty ? '' : '\n'.repeat(amount));
+const spacing = amount => (cli.flags.singleLine || cli.flags.json || cli.flags.jsonPretty ? '' : ' '.repeat(amount));
 
 const downloadSpeed = () =>
 	`${data.downloadSpeed} ${chalk.dim(data.downloadUnit)} ↓`;
@@ -84,15 +84,13 @@ const speed = () => speedText() + lineBreak(2);
 function exit() {
 	if (process.stdout.isTTY) {
 		logUpdate(`${lineBreak(2)}${spacing(4)}${speed()}`);
-	} 
-	
-	if(cli.flags.json){
-		let output = JSON.stringify(data, null, null)
-		logUpdate(output);
 	}
-	else if(cli.flags.jsonPretty){
-		let output = JSON.stringify(data, null, 4)
-		logUpdate(output);
+
+	if (cli.flags.json) {
+		logUpdate( JSON.stringify(data, null, null) );
+	}
+	else if (cli.flags.jsonPretty) {
+		logUpdate( JSON.stringify(data, null, 4) );
 	}
 	else {
 		let output = `${data.downloadSpeed} ${data.downloadUnit}`;

--- a/cli.js
+++ b/cli.js
@@ -89,6 +89,7 @@ function exit() {
 		if (cli.flags.upload) {
 			output += `\n${data.uploadSpeed} ${data.uploadUnit}`;
 		}
+		
 		console.log(output);
 	}
 

--- a/cli.js
+++ b/cli.js
@@ -88,11 +88,11 @@ function exit() {
 	
 	if(cli.flags.json){
 		let output = JSON.stringify(data, null, null)
-		console.log(output);
+		logUpdate(output);
 	}
 	else if(cli.flags.jsonPretty){
 		let output = JSON.stringify(data, null, 4)
-		console.log(output);
+		logUpdate(output);
 	}
 	else {
 		let output = `${data.downloadSpeed} ${data.downloadUnit}`;
@@ -100,7 +100,6 @@ function exit() {
 		if (cli.flags.upload) {
 			output += `\n${data.uploadSpeed} ${data.uploadUnit}`;
 		}
-
 		console.log(output);
 	}
 
@@ -128,16 +127,7 @@ if (process.stdout.isTTY) {
 
 		exit();
 	} catch (error) {
-		
-		if(cli.flags.json){
-			console.log(JSON.stringify(error, null, null));
-		}
-		else if(cli.flags.jsonPretty){
-			console.log(JSON.stringify(error, null, 4));
-		}
-		else{
-			console.error(error.message);
-		}
+		console.error(error.message);
 		process.exit(1);
 	}
 })();

--- a/cli.js
+++ b/cli.js
@@ -15,7 +15,6 @@ const cli = meow(`
 	Options
 	  --upload, -u   Measure upload speed in addition to download speed
 	  --single-line  Reduce spacing and output to a single line
-	  --json-pretty  Process output in human readable json format also forces single line 
 	  --json         Process output in json format also forces single line 
 
 	Examples
@@ -35,9 +34,6 @@ const cli = meow(`
 			type: 'boolean'
 		},
 		json: {
-			type: 'boolean'
-		},
-		jsonPretty: {
 			type: 'boolean'
 		}
 	}
@@ -87,15 +83,13 @@ function exit() {
 
 	if (cli.flags.json) {
 		logUpdate(JSON.stringify(data, null, null));
-	} else if (cli.flags.jsonPretty) {
-		logUpdate(JSON.stringify(data, null, 4));
 	} else {
 		let output = `${data.downloadSpeed} ${data.downloadUnit}`;
 
 		if (cli.flags.upload) {
 			output += `\n${data.uploadSpeed} ${data.uploadUnit}`;
 		}
-
+		
 		console.log(output);
 	}
 

--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,7 @@ const cli = meow(`
 	Options
 	  --upload, -u   Measure upload speed in addition to download speed
 	  --single-line  Reduce spacing and output to a single line
-	  --json-pretty  Process output in human readible json format also forces single line 
+	  --json-pretty  Process output in human readable json format also forces single line 
 	  --json         Process output in json format also forces single line 
 
 	Examples

--- a/cli.js
+++ b/cli.js
@@ -89,7 +89,6 @@ function exit() {
 		if (cli.flags.upload) {
 			output += `\n${data.uploadSpeed} ${data.uploadUnit}`;
 		}
-		
 		console.log(output);
 	}
 

--- a/cli.js
+++ b/cli.js
@@ -89,7 +89,7 @@ function exit() {
 		if (cli.flags.upload) {
 			output += `\n${data.uploadSpeed} ${data.uploadUnit}`;
 		}
-		
+
 		console.log(output);
 	}
 

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,6 @@ const chalk = require('chalk');
 const logUpdate = require('log-update');
 const ora = require('ora');
 const api = require('./api');
-//tllakfdja
 
 const cli = meow(`
 	Usage
@@ -87,17 +86,16 @@ function exit() {
 	}
 
 	if (cli.flags.json) {
-		logUpdate( JSON.stringify(data, null, null) );
-	}
-	else if (cli.flags.jsonPretty) {
-		logUpdate( JSON.stringify(data, null, 4) );
-	}
-	else {
+		logUpdate(JSON.stringify(data, null, null));
+	} else if (cli.flags.jsonPretty) {
+		logUpdate(JSON.stringify(data, null, 4));
+	} else {
 		let output = `${data.downloadSpeed} ${data.downloadUnit}`;
 
 		if (cli.flags.upload) {
 			output += `\n${data.uploadSpeed} ${data.uploadUnit}`;
 		}
+
 		console.log(output);
 	}
 


### PR DESCRIPTION
output examples  (_note: I used node directly to debug locally_)

I also added several common properties on the fast.com webpage currently to help improve data captured. 

for json human readable output
```
node .\cli.js --json-pretty -u
{
     "downloadSpeed": 29,
     "downloadUnit": "Mbps",
     "downloadedMb": 30,
     "uploadSpeed": 13,
     "uploadUnit": "Mbps",
     "uploadedMb": 40,
     "latency": 44,
     "bufferBloat": 75,
     "userLocation": "Chicago, US",
     "userIp": "1.2.3.4",
     "isDone": true
}
```

for json only output 
```
node .\cli.js --json -u        
{"downloadSpeed":32,"downloadUnit":"Mbps","downloadedMb":80,"uploadSpeed":10,"uploadUnit":"Mbps","uploadedMb":30,"latency":52,"bufferBloat":75,"userLocation":"Chicago, US","userIp":"1.2.3.4","isDone":true}
```