### PR TITLE
Add puppeteer executable path option

### DIFF
--- a/api.js
+++ b/api.js
@@ -45,7 +45,10 @@ module.exports = options => (
 	new Observable(observer => {
 		// Wrapped in async IIFE as `new Observable` can't handle async function
 		(async () => {
-			const browser = await puppeteer.launch({args: ['--no-sandbox']});
+			const browser = await puppeteer.launch({
+				executablePath: options.puppeteerExecutable,
+				args: ['--no-sandbox']
+			});
 			const page = await browser.newPage();
 			await page.goto('https://fast.com');
 			await init(browser, page, observer, options);

--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,7 @@ const cli = meow(`
 	Options
 	  --upload, -u   Measure upload speed in addition to download speed
 	  --single-line  Reduce spacing and output to a single line
+	  --puppeteer-executable Specify execitable path for puppetter
 
 	Examples
 	  $ fast --upload > file && cat file
@@ -28,7 +29,11 @@ const cli = meow(`
 		},
 		singleLine: {
 			type: 'boolean'
+		},
+		puppeteerExecutable: {
+			type: 'string'
 		}
+
 	}
 });
 
@@ -100,7 +105,10 @@ if (process.stdout.isTTY) {
 
 (async () => {
 	try {
-		await api({measureUpload: cli.flags.upload}).forEach(result => {
+		await api({
+			puppeteerExecutable: cli.flags.puppeteerExecutable,
+			measureUpload: cli.flags.upload
+		}).forEach(result => {
 			data = result;
 		});
 


### PR DESCRIPTION
Add puppeteer executable path option for #59 .
I tested on Raspberry Pi after install chromium-browser (`apt install chromium-browser`) using bellow command.

`node cli.js --puppeteer-executable /usr/bin/chromium-browser`

And please tell me words if you have good name for option and variable.

*OS Information*
```sh
$ cat /proc/device-tree/model
Raspberry Pi 2 Model B Rev 1.1

$ cat /etc/os-release
PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
NAME="Raspbian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
```