### PR TITLE
Add `json` flag

### DIFF
--- a/api.js
+++ b/api.js
@@ -18,7 +18,6 @@ async function init(browser, page, observer, options) {
 				uploadSpeed: Number($('#upload-value').textContent),
 				downloadUnit: $('#speed-units').textContent.trim(),
 				downloaded: Number($('#down-mb-value').textContent.trim()),
-				uploadSpeed: Number($('#upload-value').textContent),
 				uploadUnit: $('#upload-units').textContent.trim(),
 				uploaded: Number($('#up-mb-value').textContent.trim()),
 				latency: Number($('#latency-value').textContent.trim()),

--- a/api.js
+++ b/api.js
@@ -17,7 +17,14 @@ async function init(browser, page, observer, options) {
 				downloadSpeed: Number($('#speed-value').textContent),
 				uploadSpeed: Number($('#upload-value').textContent),
 				downloadUnit: $('#speed-units').textContent.trim(),
+				downloaded: Number($('#down-mb-value').textContent.trim()),
+				uploadSpeed: Number($('#upload-value').textContent),
 				uploadUnit: $('#upload-units').textContent.trim(),
+				uploaded: Number($('#up-mb-value').textContent.trim()),
+				latency: Number($('#latency-value').textContent.trim()),
+				bufferBloat: Number($('#bufferbloat-value').textContent.trim()),
+				userLocation: $('#user-location').textContent.trim(),
+				userIp: $('#user-ip').textContent.trim(),
 				isDone: Boolean(
 					$('#speed-value.succeeded') && $('#upload-value.succeeded')
 				)

--- a/cli.js
+++ b/cli.js
@@ -17,11 +17,14 @@ const cli = meow(`
 	Options
 	  --upload, -u   Measure upload speed in addition to download speed
 	  --single-line  Reduce spacing and output to a single line
+	  --json         JSON output
 
 	Examples
 	  $ fast --upload > file && cat file
 	  17 Mbps
 	  4.4 Mbps
+
+	  $ fast --upload --json
 `, {
 	flags: {
 		upload: {
@@ -30,6 +33,9 @@ const cli = meow(`
 		},
 		singleLine: {
 			type: 'boolean'
+		},
+		json: {
+			type: 'boolean'
 		}
 	}
 });
@@ -37,7 +43,8 @@ const cli = meow(`
 const main = async () => {
 	const app = render(React.createElement(ui, {
 		singleLine: cli.flags.singleLine,
-		upload: cli.flags.upload
+		upload: cli.flags.upload,
+		json: cli.flags.json,
 	}));
 
 	await app.waitUntilExit();

--- a/cli.js
+++ b/cli.js
@@ -44,7 +44,7 @@ const main = async () => {
 	const app = render(React.createElement(ui, {
 		singleLine: cli.flags.singleLine,
 		upload: cli.flags.upload,
-		json: cli.flags.json,
+		json: cli.flags.json
 	}));
 
 	await app.waitUntilExit();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 	"files": [
 		"cli.js",
 		"api.js",
-		"ui.js"
+		"ui.js",
+		"utils.js"
 	],
 	"keywords": [
 		"cli-app",

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ $ fast --help
     17 Mbps
     4.4 Mbps
 
-    fast --upload --json
+    $ fast --upload --json
 ```
 
 ##### Upload speed

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,8 @@ $ fast --help
     $ fast --upload > file && cat file
     17 Mbps
     4.4 Mbps
+
+    fast --upload --json
 ```
 
 ##### Upload speed

--- a/ui.js
+++ b/ui.js
@@ -5,6 +5,7 @@ const {useState, useEffect} = require('react');
 const {Box, Text, Newline, useApp, useStdout} = require('ink');
 const Spinner = require('ink-spinner').default;
 const api = require('./api.js');
+const {convertToMpbs} = require('./utils.js');
 
 const FixedSpacer = ({size}) => (
 	<>{' '.repeat(size)}</>
@@ -120,12 +121,20 @@ const Fast = ({singleLine, upload, json}) => {
 		if (isDone) {
 			if (json) {
 				delete data.isDone;
-				delete data.uploadUnit;
+				data.downloadSpeed = convertToMpbs(data.downloadSpeed, data.downloadUnit);
 				delete data.downloadUnit;
+
+				if (upload) {
+					data.uploadSpeed = convertToMpbs(data.uploadSpeed, data.uploadUnit);
+					delete data.uploadUnit;
+				}
+
 				write(JSON.stringify(data, null, 2));
 			}
+
 			exit();
 		}
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isDone, exit]);
 
 	if (error) {
@@ -133,7 +142,7 @@ const Fast = ({singleLine, upload, json}) => {
 	}
 
 	if (json) {
-		return <></>;
+		return null;
 	}
 
 	return (

--- a/ui.js
+++ b/ui.js
@@ -78,12 +78,12 @@ const SpeedJsonOutput = ({data}) => {
 	if (Object.keys(data).length === 0) {
 		return (
 			<Text color="cyan"><Spinner/></Text>
-		)
+		);
 	}
 
 	return (
 		<Text>{JSON.stringify(data, null, 2)}</Text>
-	)
+	);
 };
 
 const Fast = ({singleLine, upload, json}) => {
@@ -108,9 +108,10 @@ const Fast = ({singleLine, upload, json}) => {
 			// eslint-disable-next-line unicorn/no-array-for-each
 			api({measureUpload: upload}).forEach(result => {
 				if (!upload) {
-					delete result['uploaded'];
-					delete result['uploadUnit'];
+					delete result.uploaded;
+					delete result.uploadUnit;
 				}
+
 				setData(result);
 			}).catch(error_ => { // eslint-disable-line promise/prefer-await-to-then
 				setError(error_.message);
@@ -136,7 +137,7 @@ const Fast = ({singleLine, upload, json}) => {
 	}
 
 	if (json) {
-		return <SpeedJsonOutput data={data} />;
+		return <SpeedJsonOutput data={data}/>;
 	}
 
 	return (

--- a/ui.js
+++ b/ui.js
@@ -2,7 +2,7 @@
 const {promises: dns} = require('dns');
 const React = require('react');
 const {useState, useEffect} = require('react');
-const {Box, Text, Newline, useApp} = require('ink');
+const {Box, Text, Newline, useApp, useStdout} = require('ink');
 const Spinner = require('ink-spinner').default;
 const api = require('./api.js');
 
@@ -74,23 +74,12 @@ const Speed = ({upload, data}) => upload ? (
 	</>
 ) : (<DownloadSpeed {...data}/>);
 
-const SpeedJsonOutput = ({data}) => {
-	if (Object.keys(data).length === 0) {
-		return (
-			<Text color="cyan"><Spinner/></Text>
-		);
-	}
-
-	return (
-		<Text>{JSON.stringify(data, null, 2)}</Text>
-	);
-};
-
 const Fast = ({singleLine, upload, json}) => {
 	const [error, setError] = useState('');
 	const [data, setData] = useState({});
 	const [isDone, setIsDone] = useState(false);
 	const {exit} = useApp();
+	const {write} = useStdout();
 
 	useEffect(() => {
 		(async () => {
@@ -110,6 +99,7 @@ const Fast = ({singleLine, upload, json}) => {
 				if (!upload) {
 					delete result.uploaded;
 					delete result.uploadUnit;
+					delete result.uploadSpeed;
 				}
 
 				setData(result);
@@ -128,6 +118,12 @@ const Fast = ({singleLine, upload, json}) => {
 
 	useEffect(() => {
 		if (isDone) {
+			if (json) {
+				delete data.isDone;
+				delete data.uploadUnit;
+				delete data.downloadUnit;
+				write(JSON.stringify(data, null, 2));
+			}
 			exit();
 		}
 	}, [isDone, exit]);
@@ -137,7 +133,7 @@ const Fast = ({singleLine, upload, json}) => {
 	}
 
 	if (json) {
-		return <SpeedJsonOutput data={data}/>;
+		return <></>;
 	}
 
 	return (

--- a/ui.js
+++ b/ui.js
@@ -74,7 +74,19 @@ const Speed = ({upload, data}) => upload ? (
 	</>
 ) : (<DownloadSpeed {...data}/>);
 
-const Fast = ({singleLine, upload}) => {
+const SpeedJsonOutput = ({data}) => {
+	if (Object.keys(data).length === 0) {
+		return (
+			<Text color="cyan"><Spinner/></Text>
+		)
+	}
+
+	return (
+		<Text>{JSON.stringify(data, null, 2)}</Text>
+	)
+};
+
+const Fast = ({singleLine, upload, json}) => {
 	const [error, setError] = useState('');
 	const [data, setData] = useState({});
 	const [isDone, setIsDone] = useState(false);
@@ -95,6 +107,10 @@ const Fast = ({singleLine, upload}) => {
 
 			// eslint-disable-next-line unicorn/no-array-for-each
 			api({measureUpload: upload}).forEach(result => {
+				if (!upload) {
+					delete result['uploaded'];
+					delete result['uploadUnit'];
+				}
 				setData(result);
 			}).catch(error_ => { // eslint-disable-line promise/prefer-await-to-then
 				setError(error_.message);
@@ -117,6 +133,10 @@ const Fast = ({singleLine, upload}) => {
 
 	if (error) {
 		return <ErrorMessage text={error}/>;
+	}
+
+	if (json) {
+		return <SpeedJsonOutput data={data} />;
 	}
 
 	return (

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,23 @@
+const convertToMpbs = (value, unit) => {
+	// Before the webpage loads, value and unit are empty.
+	if (!unit || !value) {
+		return 0;
+	}
+
+	switch (unit.toLowerCase()) {
+		case 'gbps':
+			return value * 1000;
+		case 'mbps':
+			return value;
+		case 'kbps':
+			return value / 1000;
+		case 'bps':
+			return value / 1000000;
+		default:
+			throw new Error(`Unknown speed unit: ${unit}`);
+	}
+};
+
+module.exports = {
+	convertToMpbs
+};


### PR DESCRIPTION
Fixes #50

I replaced the `logUpdate` API in the previous PR with ink's API.
And to avoid showing upload-attributes from the `json` result when `upload` is false, added [these lines.](https://github.com/sindresorhus/fast-cli/compare/main...jopemachine:add-json?expand=1#diff-f2e0e6d1424d62935e6aac986cdca3b8bfc33333b452b3015494510fecced163R110-R113)

I'd appreciate letting me know if there are other tasks to do :)