### PR TITLE
Add Server Location Support

### DIFF
--- a/source/api.tsx
+++ b/source/api.tsx
@@ -1,5 +1,5 @@
 import {isDeepStrictEqual} from 'node:util';
-import puppeteer from 'puppeteer';
+import {launch, type Page} from 'puppeteer';
 import {delay} from 'unicorn-magic';
 import {type SpeedData, type SpeedUnit} from './types.js';
 
@@ -7,7 +7,7 @@ type Options = {
 	measureUpload?: boolean;
 };
 
-async function * monitorSpeed(page: puppeteer.Page, options?: Options): AsyncGenerator<SpeedData, void, undefined> {
+async function * monitorSpeed(page: Page, options?: Options): AsyncGenerator<SpeedData, void, undefined> {
 	let previousResult: SpeedData | undefined;
 
 	while (true) {
@@ -47,7 +47,7 @@ async function * monitorSpeed(page: puppeteer.Page, options?: Options): AsyncGen
 }
 
 export default async function * api(options?: Options): AsyncGenerator<SpeedData, void, undefined> {
-	const browser = await puppeteer.launch({
+	const browser = await launch({
 		args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
 		headless: true,
 	});

--- a/source/api.tsx
+++ b/source/api.tsx
@@ -25,6 +25,7 @@ async function * monitorSpeed(page: puppeteer.Page, options?: Options): AsyncGen
 				latency: Number($('#latency-value')?.textContent?.trim()) || 0,
 				bufferBloat: Number($('#bufferbloat-value')?.textContent?.trim()) || 0,
 				userLocation: $('#user-location')?.textContent?.trim() ?? '',
+				serverLocations: $('#server-locations')?.textContent?.split('|').map(location => location.trim()).filter(Boolean) ?? [],
 				userIp: $('#user-ip')?.textContent?.trim() ?? '',
 				isDone: Boolean($('#speed-value.succeeded') && $('#upload-value.succeeded')),
 			};

--- a/source/types.ts
+++ b/source/types.ts
@@ -10,6 +10,7 @@ export type SpeedData = {
 	readonly latency: number;
 	readonly bufferBloat: number;
 	readonly userLocation: string;
+	readonly serverLocations: string[];
 	readonly userIp: string;
 	readonly isDone: boolean;
 };

--- a/source/ui.tsx
+++ b/source/ui.tsx
@@ -127,7 +127,22 @@ const VerboseInfo: React.FC<VerboseInfoProperties> = ({data, singleLine}) => {
 						<Text dimColor>Detecting...</Text>
 					)}
 				</Box>
+				<Box>
+					<Text><FixedSpacer size={4}/></Text>
+					<Text dimColor>Server: </Text>
+					{data.serverLocations ? (
+						data.serverLocations.map((location, index) => (
+							<Text key={location}>
+								{index > 0 && <Text dimColor>{' | '}</Text>}
+								<Text color='white'>{location}</Text>
+							</Text>
+						))
+					) : (
+						<Text dimColor>Detecting...</Text>
+					)}
+				</Box>
 			</Box>
+
 		</>
 	);
 };
@@ -170,6 +185,10 @@ function formatVerboseText(data: PartialSpeedData): string[] {
 		lines.push(clientLine);
 	}
 
+	if (data.serverLocations?.length) {
+		lines.push(`Server: ${data.serverLocations.join(' | ')}`);
+	}
+
 	return lines;
 }
 
@@ -184,6 +203,7 @@ function createJsonOutput(data: PartialSpeedData, upload: boolean) {
 		latency: data.latency,
 		bufferBloat: data.bufferBloat,
 		userLocation: data.userLocation,
+		serverLocations: data.serverLocations,
 		userIp: data.userIp,
 	};
 }

--- a/test.tsx
+++ b/test.tsx
@@ -22,6 +22,7 @@ test('json output', async t => {
 	t.is(typeof data.downloadSpeed, 'number');
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 	t.regex(data.downloadUnit, /^[MGKB]bps$/);
+	t.true(Array.isArray(data.serverLocations));
 });
 
 test('upload flag', async t => {
@@ -64,6 +65,9 @@ test('verbose flag', async t => {
 
 	// Should contain client information
 	t.regex(stdout, /Client:/);
+
+	// Should contain server information
+	t.regex(stdout, /Server:/);
 });
 
 test('verbose flag in help', async t => {


### PR DESCRIPTION
This MR adds support for displaying the server location(s) used by the speed test.

## Changes

### 1. Data Model Updates
- **SpeedData Interface (source/types.ts)**: Added a new field `serverLocations` of type `string[]`. This stores the list of server locations used for the test.

### 2. API Updates
- **Scraping Logic**: Updated the `monitorSpeed` function to scrape the `#server-locations` element from the page.
- **Parsing**: The text content is split by the `|` delimiter to handle multiple server locations, trimmed, and stored as an array.

### 3. UI Updates
- **Verbose Output**:
    - Displays multiple server locations separated by ` | `.
- **JSON Output**:
    - Included the `serverLocations` array in the JSON output when the `--json` flag is used.

#### Example Verbose Output
<img width="450" height="150" alt="fast-verbose" src="https://github.com/user-attachments/assets/1b8146b5-9878-4e80-8917-09dcbe8cfd9c" />

#### Example JSON Output
```json
{
	"downloadSpeed": 190,
	"downloadUnit": "Mbps",
	"downloaded": 190,
	"uploaded": 0,
	"latency": 226,
	"bufferBloat": 231,
	"userLocation": "Oregon, US",
	"serverLocations": [
		"Seattle, US",
		"San Jose, US"
	],
	"userIp": "1xx.xxx.xxx"
}